### PR TITLE
Update mpheath's python script to v1.6

### DIFF
--- a/files/files/api_files_gen/mpheath_gen_python_3_api.py
+++ b/files/files/api_files_gen/mpheath_gen_python_3_api.py
@@ -1,10 +1,10 @@
-#! /usr/bin/env python3
+#!python3
 # Author : Michael Heath
 # Github : https://github.com/mpheath/generate-python-3-api
 # Home   : http://users.tpg.com.au/mpheath/gen_python_3_api
-# Licence: GPLv3
-# Python : 3.2 to 3.9 or later
-# Version: 1.5
+# License: GPLv3
+# Python : 3.2 to 3.11 or later
+# Version: 1.6
 
 r'''Make files for SciTE and Notepad++ for autocomplete and styling.
 
@@ -1734,9 +1734,23 @@ class Calltips():
             for item in keyword.kwlist:
                 _add_api([item])
 
+            if sys.version_info >= (3, 9):
+                for item in keyword.softkwlist:
+                    if item == '_':
+                        continue
+
+                    _add_api([item])
+
         # Add keywords to keywordclass.
         for item in keyword.kwlist:
             keywordclass0.add(item)
+
+        if sys.version_info >= (3, 9):
+            for item in keyword.softkwlist:
+                if item == '_':
+                    continue
+
+                keywordclass0.add(item)
 
         # Add to api and keywordclasses by inspecting the modules and members.
         for module, module_object in modules:


### PR DESCRIPTION
Update  `mpheath_gen_python_3_api.py`

Version set to 1.6 for Python 3.2 to 3.11 or later.

With Python v3.9+, soft keywords like `case` and `match` are added to the output. Soft keyword `_` is probably useless in an api file so it will not be added to the output.

Tested in Windows 10 virtual machine. Had some issues with running the script with Python v3.11.2 . The use of shebang

```
#! /usr/bin/env python3
```

causes the Windows Launcher `py.exe` to search the PATH for `python3` as the use of `env` causes the PATH search. Windows 10 and Windows 11 distribute 0 byte sized files named `python.exe` and `python3.exe` in PATH . To avoid this trap with trying to run 0 byte sized files, I changed the shebang to

```
#!python3
```

The Python docs recommend `/usr/`... , though with a few examples to choose from and with UNIX based systems which may have different locations for `python3`, I chose just the filename itself and let it sort itself out.