### PR TITLE
Update locale.ja.properties

### DIFF
--- a/files/files/translations/locale.ja.properties
+++ b/files/files/translations/locale.ja.properties
@@ -24,12 +24,20 @@
 # It's recommended for translations to use UTF-8 with no BOM.
 translation.encoding=UTF-8
 
+# 日本語訳 (Japanese Translation):
+# v1.62 by Suzumizaki-Kimitaka (鈴見咲君高)
+# v2.23 by gyo
+# v3.7.5 by maboroshin <pc.genkaku.in>
+# v5.5.3 by colvitto <coolvitto.hateblo.jp>
+# v5.5.3 revised by maboroshin <pc.genkaku.in>
+
 # This is to add something like:
 # Swahili translation 1.41.1 by Neil Hodgson <contact at example dot com>
 TranslationCredit=日本語訳 (Japanese Translation):\n\
-    1.62 Suzumizaki-Kimitaka (鈴見咲君高) \n\
-    2.23 gyo \n\
-    5.5.3 maboroshin <pc.genkaku.in>
+    Suzumizaki-Kimitaka (鈴見咲君高),\n\
+    gyo,\n\
+    maboroshin <pc.genkaku.in>,\n\
+    colvitto <coolvitto.hateblo.jp>
 
 # Menus
 

--- a/files/files/translations/locale.ja.properties
+++ b/files/files/translations/locale.ja.properties
@@ -27,10 +27,9 @@ translation.encoding=UTF-8
 # This is to add something like:
 # Swahili translation 1.41.1 by Neil Hodgson <contact at example dot com>
 TranslationCredit=日本語訳 (Japanese Translation):\n\
-    1.62 by Suzumizaki-Kimitaka (鈴見咲君高) \n\
-    2.23 by gyo \n\
-    3.7.5 by maboroshin <pc.genkaku.in> \n\
-    5.5.3 翻訳: colvitto (https://coolvitto.hateblo.jp)
+    1.62 Suzumizaki-Kimitaka (鈴見咲君高) \n\
+    2.23 gyo \n\
+    5.5.3 maboroshin <pc.genkaku.in>
 
 # Menus
 
@@ -414,9 +413,9 @@ The file '^0' has been deleted.=ファイル「^0」は削除されました。
 Select All Bookmarks=すべてのブックマークを選択(&B)
 
 #5.1.2
-Filter:=フィルター :
-Filter=フィルター(&L)
-Context=コンテキスト
+Filter:=絞り込み :
+Filter=絞り込み(&L)
+Context=前後の行
 
 #5.3.9
-Drop Selection=選択範囲のドロップ
+Drop Selection=選択を解除


### PR DESCRIPTION
The last translator was ambiguous in his translation. It just describes the sound of the reading. This makes it difficult to understand the meaning. I improved the translations, so his translations disappeared.

e.g.
* ```ドロップ``` : The sound notation for “Drop” in Japanese. Drag-and-drop, or AirDrop in iOS use this notation. However, it is not used in Japanese in the sense of erasing a selection. In other words, in Japanese, it only means a function that allows you to drop a selection to other applications.